### PR TITLE
FIX: tiny fixes implemented during the live run of the scripts

### DIFF
--- a/afs_ioc_migration/__main__.py
+++ b/afs_ioc_migration/__main__.py
@@ -5,6 +5,7 @@ import logging
 import sys
 import time
 from typing import Iterable
+from urllib.error import HTTPError
 
 from .transfer import migrate_repo
 
@@ -73,6 +74,9 @@ def main(args: MainArgs) -> int:
             )
             try:
                 migrate_repo(afs_path=user_path, org=args.org, dry_run=args.dry_run)
+            except HTTPError:
+                logger.error("Stopping on HTTPError")
+                raise
             except Exception:
                 if args.stop_on_error:
                     raise

--- a/afs_ioc_migration/lock_repo.py
+++ b/afs_ioc_migration/lock_repo.py
@@ -17,9 +17,11 @@ def lock_file_repo(path: str, org: str) -> None:
     repo_info = RepoInfo.from_afs(afs_source=path, org=org)
     hooks_dir = Path(repo_info.afs_source) / "hooks"
     if not hooks_dir.is_dir():
-        raise ValueError(
-            f"{path} is not a valid git repo, it has no hooks subdirectory."
-        )
+        hooks_dir = Path(repo_info.afs_source) / ".git" / "hooks"
+        if not hooks_dir.is_dir():
+            raise ValueError(
+                f"{path} is not a valid git repo, it has no hooks subdirectory."
+            )
 
     template_path = Path(__file__).parent / "hook_template.txt"
     with template_path.open("r") as fd:


### PR DESCRIPTION
1. Stop the full script on any uncaught HTTPError (other errors will continue). These include e.g. 403 permissions errors (rate limiting) or other weird unexpected errors that I haven't thought of.
2. Check an additional location for the hooks folder.